### PR TITLE
fix: Trim whitespaces from timezones before attempting to parse them

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -89,7 +89,7 @@ defmodule Mail.Parsers.RFC2822 do
     hour = hour |> String.to_integer()
     minute = minute |> String.to_integer()
     second = second |> String.to_integer()
-    offset = offset_from_timezone(timezone)
+    offset = timezone |> String.trim() |> offset_from_timezone()
 
     {{year, month, date}, {hour, minute, second}}
     |> :calendar.datetime_to_gregorian_seconds()

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -133,12 +133,14 @@ defmodule Mail.Parsers.RFC2822Test do
     assert erl_from_timestamp("1 Feb 2016 01:02:03 +0000") == {{2016, 2, 1}, {1, 2, 3}}
     assert erl_from_timestamp(" 1 Mar 2016 11:12:13 +0000") == {{2016, 3, 1}, {11, 12, 13}}
     assert erl_from_timestamp("\t1 Apr 2016 22:33:44 +0000") == {{2016, 4, 1}, {22, 33, 44}}
-    assert erl_from_timestamp("12 Jan 2016 00:00:00 +0000") == {{2016, 1, 12}, {0, 0, 0}}
+    assert erl_from_timestamp("12 Jan 2016 00:00:00 +0000 ") == {{2016, 1, 12}, {0, 0, 0}}
     assert erl_from_timestamp("25 Dec 2016 00:00:00 +0000 (UTC)") == {{2016, 12, 25}, {0, 0, 0}}
     assert erl_from_timestamp("03 Apr 2017 12:30:55 GMT") == {{2017, 4, 3}, {12, 30, 55}}
+    assert erl_from_timestamp("07 Mar 2022 22:19:17 UTC ") == {{2022, 3, 7}, {22, 19, 17}}
     # The spec specifies that the seconds are optional
     assert erl_from_timestamp("14 Jun 2019 11:24 +0000") == {{2019, 6, 14}, {11, 24, 0}}
     assert erl_from_timestamp("28 JUN 2021 09:10 +0200") == {{2021, 6, 28}, {7, 10, 0}}
+    assert erl_from_timestamp("Tue, 1 Mar 2022 19:13 +0800 ") == {{2022, 3, 1}, {11, 13, 00}}
   end
 
   test "erl_from_timestamp\1 with invalid RFC2822 timestamps (found in the wild)" do


### PR DESCRIPTION
#### Context

`Mail.Parsers.RFC2822.offset_from_timezone/1` currently fails with a `FunctionClauseError` if the input has trailing whitespaces.

```
no function clause matching in Mail.Parsers.RFC2822.offset_from_timezone/1

The following arguments were given to Mail.Parsers.RFC2822.offset_from_timezone/1:

    # 1
    "UTC "
```

#### Change

Trim whitespaces from the timezone string before passing into `Mail.Parsers.RFC2822.offset_from_timezone/1`